### PR TITLE
Relax the version range of msgpack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3.3
+  - 2.4.0
 
 script: bundle exec rake test
 

--- a/msgpack-rpc.gemspec
+++ b/msgpack-rpc.gemspec
@@ -13,11 +13,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "MessagePack-RPC, asynchronous RPC library using MessagePack"
 
-  s.add_runtime_dependency "msgpack", ["~> 0.5.10"]
+  s.add_runtime_dependency "msgpack", [">= 0.5"]
   s.add_runtime_dependency "cool.io", ["~> 1.4.3"]
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "test-unit"
   s.add_development_dependency 'bundler', ["~> 1.0"]
 end
-


### PR DESCRIPTION
To use `msgpack-rpc` with Ruby 2.4, it has to use `msgpack` which version is 1.0.3 at least.

Test passes against Ruby 2.3 and 2.4 too.
https://travis-ci.org/kogasoftware/msgpack-rpc-ruby