### PR TITLE
bump cool.io to 1.8

### DIFF
--- a/msgpack-rpc.gemspec
+++ b/msgpack-rpc.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.summary = "MessagePack-RPC, asynchronous RPC library using MessagePack"
 
   s.add_runtime_dependency "msgpack"
-  s.add_runtime_dependency "cool.io", ["~> 1.7.0"]
+  s.add_runtime_dependency "cool.io", ["~> 1.8"]
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "test-unit"


### PR DESCRIPTION
1.8.0 adds support for ruby 3.3 https://github.com/socketry/cool.io/pull/79 

Also bring the ~> to be just 1.8 and not 1.8.0 to allow for later 1.x versions in the future to hopefully avoid more patches like this just for the cool.io version.

